### PR TITLE
[纯 AI] 修复 LXserver 播放稳定性与电视遥控器分页

### DIFF
--- a/app/src/main/java/top/boluofan/musictv/ConfigActivity.java
+++ b/app/src/main/java/top/boluofan/musictv/ConfigActivity.java
@@ -286,13 +286,14 @@ public class ConfigActivity extends AppCompatActivity {
             }else {
 
                 LxApiService apiService = LxRetrofitClient.getLxAuthService(this);
-                apiService.verifyUser(body).enqueue(new retrofit2.Callback<LoginResponse>() {
+                apiService.loginUser(body).enqueue(new retrofit2.Callback<LoginResponse>() {
                     @Override
                     public void onResponse(retrofit2.Call<LoginResponse> call, retrofit2.Response<LoginResponse> response) {
                         btnConnect.setEnabled(true);
                         btnConnect.setText("连　接");
 
                         if (response.isSuccessful() && response.body() != null && response.body().isSuccess()) {
+                            LxRetrofitClient.saveToken(ConfigActivity.this, response.body().getToken());
                             Toast.makeText(ConfigActivity.this, "登录成功", Toast.LENGTH_SHORT).show();
                         } else {
                             Toast.makeText(ConfigActivity.this, "用户名或密码错误，将以游客身份使用", Toast.LENGTH_LONG).show();

--- a/app/src/main/java/top/boluofan/musictv/FloatingPlayerWindow.java
+++ b/app/src/main/java/top/boluofan/musictv/FloatingPlayerWindow.java
@@ -29,7 +29,6 @@ import androidx.media3.session.SessionToken;
 
 import com.bumptech.glide.Glide;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 
 public class FloatingPlayerWindow {
     private static final String TAG = "FloatingPlayerWindow";
@@ -56,6 +55,7 @@ public class FloatingPlayerWindow {
     private Runnable fadeOutRunnable;
     private boolean isPlaying = false;
     private boolean isConnected = false;
+    private boolean isReleased = false;
     private boolean isFadedOut = false;
     private boolean isFocused = false;
     private int collapsedWidth = 96;
@@ -328,15 +328,22 @@ public class FloatingPlayerWindow {
     }
 
     public void connectToService() {
-        if (isConnected) return;
+        if (isConnected || isReleased) return;
         
         SessionToken sessionToken = new SessionToken(context, 
                 new ComponentName(context, MusicService.class));
         
-        controllerFuture = new MediaController.Builder(context, sessionToken).buildAsync();
-        controllerFuture.addListener(() -> {
+        final ListenableFuture<MediaController> pendingController =
+                new MediaController.Builder(context, sessionToken).buildAsync();
+        controllerFuture = pendingController;
+        pendingController.addListener(() -> {
             try {
-                player = controllerFuture.get();
+                MediaController resolvedController = pendingController.get();
+                if (isReleased || activity.isFinishing() || activity.isDestroyed()) {
+                    MediaController.releaseFuture(pendingController);
+                    return;
+                }
+                player = resolvedController;
                 isConnected = true;
                 playerListener = new Player.Listener() {
                     @Override
@@ -362,7 +369,7 @@ public class FloatingPlayerWindow {
             } catch (Exception e) {
                 Log.e(TAG, "Failed to get MediaController: " + e.getMessage());
             }
-        }, MoreExecutors.directExecutor());
+        }, androidx.core.content.ContextCompat.getMainExecutor(activity));
     }
 
     private void updatePlayPauseButton() {
@@ -455,6 +462,8 @@ public class FloatingPlayerWindow {
     }
 
     public void release() {
+        if (isReleased) return;
+        isReleased = true;
         isFocused = false;
         if (scaleAnim != null) {
             scaleAnim.cancel();
@@ -477,6 +486,7 @@ public class FloatingPlayerWindow {
         }
         if (controllerFuture != null) {
             MediaController.releaseFuture(controllerFuture);
+            controllerFuture = null;
         }
         
         if (container != null) {
@@ -496,6 +506,8 @@ public class FloatingPlayerWindow {
         }
         
         isConnected = false;
+        player = null;
+        playerListener = null;
     }
     
     public View getContainer() {

--- a/app/src/main/java/top/boluofan/musictv/MusicService.java
+++ b/app/src/main/java/top/boluofan/musictv/MusicService.java
@@ -3,8 +3,6 @@ package top.boluofan.musictv;
 import android.app.PendingIntent;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.OptIn;
@@ -22,15 +20,11 @@ import androidx.media3.session.MediaSessionService;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
-import retrofit2.Call;
-import retrofit2.Callback;
 import retrofit2.Response;
 import top.boluofan.musictv.api.LxApiService;
 import top.boluofan.musictv.api.LxRetrofitClient;
+import top.boluofan.musictv.api.model.LoginResponse;
 import top.boluofan.musictv.api.model.MusicUrlResponse;
 
 public class MusicService extends MediaSessionService {
@@ -38,20 +32,16 @@ public class MusicService extends MediaSessionService {
     private static final String PREFS_NAME = "LxMusicPrefs";
     private static final String RESOLVE_SCHEME = "lxmusic";
     private static final String RESOLVE_HOST = "resolve";
-    private static final int RESOLVE_TIMEOUT_SECONDS = 30;
 
     private MediaSession mediaSession;
     private ExoPlayer player;
     private LxApiService apiService;
-    private Handler mainHandler;
     private String quality;
 
     @OptIn(markerClass = UnstableApi.class)
     @Override
     public void onCreate() {
         super.onCreate();
-
-        mainHandler = new Handler(Looper.getMainLooper());
 
         android.content.SharedPreferences settings = getSharedPreferences(PREFS_NAME, 0);
         quality = settings.getString("quality", LxRetrofitClient.QUALITY_320K);
@@ -84,7 +74,7 @@ public class MusicService extends MediaSessionService {
 
                         Log.d(TAG, "Resolved URL: " + resolvedUrl);
 
-                        resolvedUrl = fixUrlFormat(resolvedUrl);
+                        resolvedUrl = preparePlaybackUrl(resolvedUrl);
 
                         return dataSpec.withUri(Uri.parse(resolvedUrl));
                     }
@@ -101,9 +91,6 @@ public class MusicService extends MediaSessionService {
                 .setMediaSourceFactory(new DefaultMediaSourceFactory(this).setDataSourceFactory(resolvingFactory))
                 .setAudioAttributes(audioAttributes, true)
                 .setWakeMode(C.WAKE_MODE_NETWORK)
-                .setLoadControl(new androidx.media3.exoplayer.DefaultLoadControl.Builder()
-                        .setBufferDurationsMs(15000, 30000, 1500, 2000)
-                        .build())
                 .build();
 
         Intent intent = new Intent(this, top.boluofan.musictv.ui.LibraryActivity.class);
@@ -133,7 +120,23 @@ public class MusicService extends MediaSessionService {
         return url;
     }
 
-    private String resolveMusicUrlSync(String source, String songmid, String name) {
+    private String preparePlaybackUrl(String url) throws IOException {
+        String resolvedUrl = fixUrlFormat(url);
+        String serverBaseUrl = LxRetrofitClient.getPureServerUrl(this);
+        if (serverBaseUrl == null || serverBaseUrl.isEmpty()) {
+            throw new IOException("Server address is empty");
+        }
+
+        Uri resolvedUri = Uri.parse(resolvedUrl);
+        String scheme = resolvedUri.getScheme();
+        if (scheme == null || scheme.isEmpty()) {
+            String relativePath = resolvedUrl.startsWith("/") ? resolvedUrl : "/" + resolvedUrl;
+            return serverBaseUrl + relativePath;
+        }
+        return resolvedUrl;
+    }
+
+    private String resolveMusicUrlSync(String source, String songmid, String name) throws IOException {
         Map<String, Object> body = new HashMap<>();
         Map<String, Object> songInfo = new HashMap<>();
         songInfo.put("source", source);
@@ -144,44 +147,78 @@ public class MusicService extends MediaSessionService {
         body.put("songInfo", songInfo);
         body.put("quality", quality);
 
-        AtomicReference<String> resultUrl = new AtomicReference<>();
-        CountDownLatch latch = new CountDownLatch(1);
-
-        apiService.getMusicUrl(body).enqueue(new Callback<MusicUrlResponse>() {
-            @Override
-            public void onResponse(Call<MusicUrlResponse> call, Response<MusicUrlResponse> response) {
-                if (response.isSuccessful() && response.body() != null) {
-                    MusicUrlResponse urlResponse = response.body();
-                    if (urlResponse.isValid()) {
-                        String url = urlResponse.getUrl();
-                        Log.d(TAG, "API returned URL: " + url);
-                        resultUrl.set(url);
-                    } else {
-                        Log.e(TAG, "Invalid URL response: " + urlResponse);
-                    }
-                } else {
-                    Log.e(TAG, "API call failed: " + response.code());
-                }
-                latch.countDown();
-            }
-
-            @Override
-            public void onFailure(Call<MusicUrlResponse> call, Throwable t) {
-                Log.e(TAG, "Failed to resolve URL: " + t.getMessage());
-                latch.countDown();
-            }
-        });
+        String username = LxRetrofitClient.getUsername(this);
+        String password = LxRetrofitClient.getPassword(this);
+        String token = LxRetrofitClient.getToken(this);
+        boolean isLxServer = LxRetrofitClient.isLXServerApi(this);
 
         try {
-            if (!latch.await(RESOLVE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                Log.e(TAG, "URL resolution timed out");
+            if (isLxServer && (token == null || token.isEmpty())
+                    && !username.isEmpty() && !password.isEmpty()) {
+                token = loginAndSaveToken(username, password);
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            Log.e(TAG, "URL resolution interrupted");
-        }
 
-        return resultUrl.get();
+            Response<MusicUrlResponse> response = apiService
+                    .getMusicUrl(username, password, token, body)
+                    .execute();
+
+            if (isLxServer && response.code() == 401
+                    && !username.isEmpty() && !password.isEmpty()) {
+                token = loginAndSaveToken(username, password);
+                if (token != null && !token.isEmpty()) {
+                    response = apiService
+                            .getMusicUrl(username, password, token, body)
+                            .execute();
+                }
+            }
+
+            if (response.isSuccessful() && response.body() != null) {
+                MusicUrlResponse urlResponse = response.body();
+                if (urlResponse.isValid()) {
+                    String url = urlResponse.getUrl();
+                    Log.d(TAG, "API returned URL: " + url);
+                    return url;
+                }
+                throw new IOException("Server returned an empty music URL");
+            }
+
+            String detail = "";
+            if (response.errorBody() != null) {
+                detail = response.errorBody().string();
+                if (detail.length() > 8000) {
+                    detail = detail.substring(0, 8000) + "\n…(truncated after 8000 characters)";
+                }
+            }
+            throw new IOException("Music URL request failed: HTTP "
+                    + response.code() + (detail.isEmpty() ? "" : " - " + detail));
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to resolve URL: " + e.getMessage());
+            throw e;
+        }
+    }
+
+    private String loginAndSaveToken(String username, String password) {
+        Map<String, String> credentials = new HashMap<>();
+        credentials.put("username", username);
+        credentials.put("password", password);
+
+        try {
+            Response<LoginResponse> response = LxRetrofitClient
+                    .getLxAuthService(this)
+                    .loginUser(credentials)
+                    .execute();
+            if (response.isSuccessful() && response.body() != null && response.body().isSuccess()) {
+                String token = response.body().getToken();
+                if (token != null && !token.isEmpty()) {
+                    LxRetrofitClient.saveToken(this, token);
+                    return token;
+                }
+            }
+            Log.e(TAG, "LXserver login failed while refreshing playback token: " + response.code());
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to refresh playback token: " + e.getMessage());
+        }
+        return null;
     }
 
     public static Uri buildResolveUri(String source, String songmid, String name) {

--- a/app/src/main/java/top/boluofan/musictv/PlayerActivity.java
+++ b/app/src/main/java/top/boluofan/musictv/PlayerActivity.java
@@ -1,6 +1,9 @@
 package top.boluofan.musictv;
 
 import android.animation.ObjectAnimator;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
@@ -15,6 +18,7 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
@@ -646,15 +650,15 @@ public class PlayerActivity extends AppCompatActivity {
             public void onPlayerError(androidx.media3.common.PlaybackException error) {
                 String errorMsg = error.getErrorCodeName() + " - " + error.getMessage();
                 Throwable cause = error.getCause();
-                if (cause != null) {
-                    if (cause.getMessage() != null) {
-                        errorMsg += "\nCause: " + cause.getMessage();
-                    } else {
-                        errorMsg += "\nCause: " + cause.toString();
-                    }
+                int depth = 0;
+                while (cause != null && depth < 4) {
+                    String causeMessage = cause.getMessage();
+                    errorMsg += "\nCause: " + (causeMessage != null ? causeMessage : cause.toString());
+                    cause = cause.getCause();
+                    depth++;
                 }
                 Log.e(TAG, "Player Error: " + errorMsg);
-                Toast.makeText(PlayerActivity.this, "播放失败: " + errorMsg, Toast.LENGTH_LONG).show();
+                showPlaybackError(errorMsg);
             }
         });
         
@@ -668,6 +672,30 @@ public class PlayerActivity extends AppCompatActivity {
         }
         if (player.isPlaying()) startProgressUpdater();
         updateControlsUI();
+    }
+
+    private void showPlaybackError(String errorMessage) {
+        String versionName = "unknown";
+        try {
+            versionName = getPackageManager()
+                    .getPackageInfo(getPackageName(), 0)
+                    .versionName;
+        } catch (Exception ignored) {
+        }
+        final String fullMessage = "版本: " + versionName + "\n\n" + errorMessage;
+        runOnUiThread(() -> new AlertDialog.Builder(PlayerActivity.this)
+                .setTitle("播放失败（完整错误）")
+                .setMessage(fullMessage)
+                .setNeutralButton("复制错误", (dialog, which) -> {
+                    ClipboardManager clipboard =
+                            (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+                    if (clipboard != null) {
+                        clipboard.setPrimaryClip(ClipData.newPlainText("music-tv playback error", fullMessage));
+                        Toast.makeText(PlayerActivity.this, "完整错误已复制", Toast.LENGTH_SHORT).show();
+                    }
+                })
+                .setPositiveButton("关闭", null)
+                .show());
     }
 
     private void updateMetadata(MediaItem mediaItem) {

--- a/app/src/main/java/top/boluofan/musictv/api/LxApiService.java
+++ b/app/src/main/java/top/boluofan/musictv/api/LxApiService.java
@@ -29,6 +29,9 @@ public interface LxApiService {
     @POST("verify")
     Call<LoginResponse> verifyUser(@Body Map<String, String> body);
 
+    @POST("login")
+    Call<LoginResponse> loginUser(@Body Map<String, String> body);
+
     @POST("auth/login")
     Call<MiAuthTokenResponse> miMusicLogin(@Body Map<String, String> body);
 
@@ -56,7 +59,12 @@ public interface LxApiService {
     );
 
     @POST("url")
-    Call<MusicUrlResponse> getMusicUrl(@Body Map<String, Object> body);
+    Call<MusicUrlResponse> getMusicUrl(
+            @Header("x-user-name") String username,
+            @Header("x-user-password") String password,
+            @Header("x-user-token") String token,
+            @Body Map<String, Object> body
+    );
 
     @GET("lyric")
     Call<LyricInfo> getLyric(@Query("source") String source, @Query("songmid") String songmid, @Query("quality") String quality);

--- a/app/src/main/java/top/boluofan/musictv/api/LxRetrofitClient.java
+++ b/app/src/main/java/top/boluofan/musictv/api/LxRetrofitClient.java
@@ -208,6 +208,11 @@ public class LxRetrofitClient {
         return prefs.getString(KEY_TOKEN, "");
     }
 
+    public static void saveToken(Context context, String token) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        prefs.edit().putString(KEY_TOKEN, token == null ? "" : token).apply();
+    }
+
     public static String getMiAccessToken(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getString(KEY_MI_ACCESS_TOKEN, "");
@@ -233,8 +238,13 @@ public class LxRetrofitClient {
 
     public static String getPureServerUrl(Context context) {
         String baseUrl = getServerUrl(context);
-        if (baseUrl.isEmpty()) {
-            return "http://localhost:58091";
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            return isMiMusicApi(context)
+                    ? "http://localhost:58091"
+                    : "http://localhost:9527";
+        }
+        if (!baseUrl.startsWith("http://") && !baseUrl.startsWith("https://")) {
+            baseUrl = "http://" + baseUrl;
         }
         while (baseUrl.endsWith("/")) {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);

--- a/app/src/main/java/top/boluofan/musictv/api/MusicRepository.java
+++ b/app/src/main/java/top/boluofan/musictv/api/MusicRepository.java
@@ -47,10 +47,11 @@ public class MusicRepository {
         body.put("username", username);
         body.put("password", password);
 
-        apiService.verifyUser(body).enqueue(new retrofit2.Callback<LoginResponse>() {
+        apiService.loginUser(body).enqueue(new retrofit2.Callback<LoginResponse>() {
             @Override
             public void onResponse(Call<LoginResponse> call, Response<LoginResponse> response) {
                 if (response.isSuccessful() && response.body() != null && response.body().isSuccess()) {
+                    LxRetrofitClient.saveToken(context, response.body().getToken());
                     callback.onSuccess(true);
                 } else {
                     callback.onError("认证失败");
@@ -130,7 +131,12 @@ public class MusicRepository {
         body.put("songInfo", songInfo);
         body.put("quality", quality);
 
-        apiService.getMusicUrl(body).enqueue(new retrofit2.Callback<MusicUrlResponse>() {
+        String username = LxRetrofitClient.getUsername(context);
+        String password = LxRetrofitClient.getPassword(context);
+        String token = LxRetrofitClient.getToken(context);
+
+        LxApiService musicApiService = LxRetrofitClient.getApiService(context);
+        musicApiService.getMusicUrl(username, password, token, body).enqueue(new retrofit2.Callback<MusicUrlResponse>() {
             @Override
             public void onResponse(Call<MusicUrlResponse> call, Response<MusicUrlResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {

--- a/app/src/main/java/top/boluofan/musictv/api/model/LoginResponse.java
+++ b/app/src/main/java/top/boluofan/musictv/api/model/LoginResponse.java
@@ -9,6 +9,12 @@ public class LoginResponse {
     @SerializedName("message")
     private String message;
 
+    @SerializedName("token")
+    private String token;
+
+    @SerializedName("username")
+    private String username;
+
     public boolean isSuccess() {
         return success;
     }
@@ -23,5 +29,21 @@ public class LoginResponse {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 }

--- a/app/src/main/java/top/boluofan/musictv/ui/MainActivity.java
+++ b/app/src/main/java/top/boluofan/musictv/ui/MainActivity.java
@@ -78,12 +78,19 @@ public class MainActivity extends AppCompatActivity {
     protected void onStart() {
         super.onStart();
         SessionToken sessionToken = new SessionToken(this, new ComponentName(this, MusicService.class));
-        controllerFuture = new MediaController.Builder(this, sessionToken).buildAsync();
-        controllerFuture.addListener(() -> {
+        final ListenableFuture<MediaController> pendingController =
+                new MediaController.Builder(this, sessionToken).buildAsync();
+        controllerFuture = pendingController;
+        pendingController.addListener(() -> {
             try {
-                player = controllerFuture.get();
+                MediaController resolvedController = pendingController.get();
+                if (isFinishing() || isDestroyed() || controllerFuture != pendingController) {
+                    MediaController.releaseFuture(pendingController);
+                    return;
+                }
+                player = resolvedController;
             } catch (Exception e) {
-                e.printStackTrace();
+                Log.e(TAG, "Failed to connect media controller", e);
             }
         }, androidx.core.content.ContextCompat.getMainExecutor(this));
     }
@@ -93,7 +100,9 @@ public class MainActivity extends AppCompatActivity {
         super.onStop();
         if (controllerFuture != null) {
             MediaController.releaseFuture(controllerFuture);
+            controllerFuture = null;
         }
+        player = null;
     }
 
     private void initViews() {

--- a/app/src/main/java/top/boluofan/musictv/ui/SongSquareFragment.java
+++ b/app/src/main/java/top/boluofan/musictv/ui/SongSquareFragment.java
@@ -6,7 +6,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.KeyEvent;
-import android.widget.ImageButton;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -24,8 +24,6 @@ import top.boluofan.musictv.R;
 import top.boluofan.musictv.FloatingPlayerWindow;
 import top.boluofan.musictv.api.LxApiService;
 import top.boluofan.musictv.api.LxRetrofitClient;
-import top.boluofan.musictv.api.model.MiPlaylist;
-import top.boluofan.musictv.api.model.MiPlaylistListResponse;
 import top.boluofan.musictv.api.model.Playlist;
 import top.boluofan.musictv.ui.adapter.SquarePlaylistAdapter;
 
@@ -34,12 +32,17 @@ import java.util.List;
 
 public class SongSquareFragment extends Fragment {
     private static final String TAG = "SongSquareFragment";
+    private static final int TV_PAGE_SIZE = 12;
     
     private RecyclerView rvSourceList;
     private RecyclerView rvPlaylists;
     private ProgressBar loadingProgress;
+    private Button btnPrevPage;
+    private Button btnNextPage;
+    private TextView tvPageNumber;
     
-    private List<Playlist> playlists = new ArrayList<>();
+    private final List<Playlist> playlists = new ArrayList<>();
+    private final List<Playlist> loadedPlaylists = new ArrayList<>();
     private String currentSource = "mg";
     private int currentSourceIndex = 0;
     
@@ -48,9 +51,10 @@ public class SongSquareFragment extends Fragment {
     
     private SquarePlaylistAdapter playlistAdapter;
     private int currentPage = 1;
-    private boolean hasMore = true;
+    private int remotePage = 1;
+    private boolean remoteHasMore = true;
     private boolean isLoading = false;
-    private boolean isLoadingMore = false;
+    private Call<okhttp3.ResponseBody> activePageCall;
     
     private FloatingPlayerWindow floatingPlayerWindow;
     private GridLayoutManager gridLayoutManager;
@@ -81,6 +85,9 @@ public class SongSquareFragment extends Fragment {
         rvSourceList = view.findViewById(R.id.rvSourceList);
         rvPlaylists = view.findViewById(R.id.rvPlaylists);
         loadingProgress = view.findViewById(R.id.loadingProgress);
+        btnPrevPage = view.findViewById(R.id.btnPrevPage);
+        btnNextPage = view.findViewById(R.id.btnNextPage);
+        tvPageNumber = view.findViewById(R.id.tvPageNumber);
     }
 
     private void setupRecyclerViews() {
@@ -116,33 +123,9 @@ public class SongSquareFragment extends Fragment {
         gridLayoutManager = new GridLayoutManager(requireContext(), spanCount);
         rvPlaylists.setLayoutManager(gridLayoutManager);
         
-        rvPlaylists.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
-                super.onScrolled(recyclerView, dx, dy);
-                GridLayoutManager layoutManager = (GridLayoutManager) recyclerView.getLayoutManager();
-                if (layoutManager == null || isLoadingMore || !hasMore) return;
-                
-                int spanCount = gridLayoutManager.getSpanCount();
-                int totalItemCount = layoutManager.getItemCount();
-                int lastVisiblePosition = layoutManager.findLastVisibleItemPosition();
-                
-                if (dy <= 0) return;
-                
-                if (lastVisiblePosition >= totalItemCount - spanCount * 2) {
-                    loadMorePlaylists();
-                }
-            }
-        });
-        
-        rvPlaylists.setOnFocusChangeListener((v, hasFocus) -> {
-            if (!hasFocus) {
-                View bottomNav = getActivity().findViewById(R.id.bottomNav);
-                if (bottomNav != null) {
-                    bottomNav.requestFocus();
-                }
-            }
-        });
+        btnPrevPage.setOnClickListener(v -> changePage(-1));
+        btnNextPage.setOnClickListener(v -> changePage(1));
+        updatePager();
         
         playlistAdapter.setOnItemClickListener(playlist -> {
             Intent intent = new Intent(requireContext(), PlaylistDetailActivity.class);
@@ -162,13 +145,21 @@ public class SongSquareFragment extends Fragment {
     
     private void selectSource(int position) {
         if (position < 0 || position >= SOURCES.length) return;
+
+        if (activePageCall != null) {
+            activePageCall.cancel();
+            activePageCall = null;
+        }
+        isLoading = false;
         
         currentSourceIndex = position;
         String newSource = SOURCES[position];
         
         currentSource = newSource;
         currentPage = 1;
-        hasMore = true;
+        remotePage = 1;
+        remoteHasMore = true;
+        loadedPlaylists.clear();
         playlists.clear();
         
         if (playlistAdapter != null) {
@@ -179,7 +170,7 @@ public class SongSquareFragment extends Fragment {
             rvSourceList.getAdapter().notifyDataSetChanged();
         }
         
-        loadPlaylists();
+        loadPlaylists(false);
         
         rvSourceList.post(() -> {
             if (rvSourceList.getChildCount() > position) {
@@ -197,15 +188,18 @@ public class SongSquareFragment extends Fragment {
         selectSource(0);
     }
 
-    private void loadPlaylists() {
+    private void loadPlaylists(boolean advanceAfterLoad) {
         if (isLoading) return;
         isLoading = true;
         showLoading(true);
+        updatePager();
 
         LxApiService apiService = LxRetrofitClient.getApiService(requireContext());
-        apiService.getSongListList(currentSource, "", "hot", currentPage).enqueue(new Callback<okhttp3.ResponseBody>() {
+        activePageCall = apiService.getSongListList(currentSource, "", "hot", remotePage);
+        activePageCall.enqueue(new Callback<okhttp3.ResponseBody>() {
             @Override
             public void onResponse(Call<okhttp3.ResponseBody> call, Response<okhttp3.ResponseBody> response) {
+                if (!isAdded() || call != activePageCall) return;
                 isLoading = false;
                 showLoading(false);
                 if (response.isSuccessful() && response.body() != null) {
@@ -214,21 +208,35 @@ public class SongSquareFragment extends Fragment {
                         com.google.gson.Gson gson = new com.google.gson.Gson();
                         SongListResult result = gson.fromJson(bodyStr, SongListResult.class);
                         if (result != null && result.getList() != null) {
-                            if (currentPage == 1) {
-                                playlists.clear();
+                            List<Playlist> remoteItems = result.getList();
+                            if (remotePage == 1) {
+                                loadedPlaylists.clear();
                             }
-                            hasMore = result.getList().size() >= 20;
-                            playlists.addAll(result.getList());
-                            updatePlaylistList();
+                            loadedPlaylists.addAll(remoteItems);
+                            remoteHasMore = result.hasMore(remotePage, remoteItems.size());
+
+                            if (advanceAfterLoad) {
+                                int nextStart = currentPage * TV_PAGE_SIZE;
+                                if (nextStart < loadedPlaylists.size()) {
+                                    currentPage++;
+                                } else {
+                                    remoteHasMore = false;
+                                }
+                            }
+                            showCurrentPage();
                         }
                     } catch (Exception e) {
-                        Toast.makeText(requireContext(), "解析失败", Toast.LENGTH_SHORT).show();
+                        if (isAdded()) {
+                            Toast.makeText(requireContext(), "解析失败", Toast.LENGTH_SHORT).show();
+                        }
                     }
                 } else {
                     Toast.makeText(requireContext(), "加载失败", Toast.LENGTH_SHORT).show();
                 }
+                updatePager();
                 
-                rvSourceList.post(() -> {
+                if (!advanceAfterLoad) rvSourceList.post(() -> {
+                    if (!isAdded() || rvSourceList == null) return;
                     if (rvSourceList.getChildCount() > currentSourceIndex) {
                         View itemView = rvSourceList.getChildAt(currentSourceIndex);
                         if (itemView != null && itemView.isFocusable()) {
@@ -240,102 +248,65 @@ public class SongSquareFragment extends Fragment {
 
             @Override
             public void onFailure(Call<okhttp3.ResponseBody> call, Throwable t) {
+                if (call.isCanceled() || !isAdded() || call != activePageCall) return;
+                if (advanceAfterLoad && remotePage > 1) {
+                    remotePage--;
+                }
                 isLoading = false;
                 showLoading(false);
                 Toast.makeText(requireContext(), "网络错误: " + t.getMessage(), Toast.LENGTH_SHORT).show();
+                updatePager();
             }
         });
     }
 
-    private void loadMorePlaylists() {
-        if (isLoadingMore || !hasMore) return;
-        boolean isMiMusicMode = LxRetrofitClient.isMiMusicApi(requireContext());
-        // MiMusic 模式使用分页加载
-        if (isMiMusicMode) {
-            loadMoreMiMusicPlaylists();
-            return;
-        }
-
-        isLoadingMore = true;
-        currentPage++;
-
-        playlistAdapter.setShowFooter(true);
-
-        LxApiService apiService = LxRetrofitClient.getApiService(requireContext());
-        apiService.getSongListList(currentSource, "", "hot", currentPage).enqueue(new Callback<okhttp3.ResponseBody>() {
-            @Override
-            public void onResponse(Call<okhttp3.ResponseBody> call, Response<okhttp3.ResponseBody> response) {
-                isLoadingMore = false;
-                playlistAdapter.setShowFooter(false);
-                if (response.isSuccessful() && response.body() != null) {
-                    try {
-                        String bodyStr = response.body().string();
-                        com.google.gson.Gson gson = new com.google.gson.Gson();
-                        SongListResult result = gson.fromJson(bodyStr, SongListResult.class);
-                        if (result != null && result.getList() != null) {
-                            hasMore = result.getList().size() >= 20;
-                            playlists.addAll(result.getList());
-                            playlistAdapter.addData(result.getList());
-                        }
-                    } catch (Exception e) {
-                        currentPage--;
-                        Toast.makeText(requireContext(), "解析失败", Toast.LENGTH_SHORT).show();
-                    }
-                } else {
-                    currentPage--;
-                }
-            }
-
-            @Override
-            public void onFailure(Call<okhttp3.ResponseBody> call, Throwable t) {
-                isLoadingMore = false;
-                playlistAdapter.setShowFooter(false);
-                currentPage--;
-            }
-        });
-    }
-
-    private void loadMoreMiMusicPlaylists() {
-        if (isLoadingMore || !hasMore) return;
-        isLoadingMore = true;
-        currentPage++;
-
-        playlistAdapter.setShowFooter(true);
-
-        LxApiService apiService = LxRetrofitClient.getMiMusicAuthService(requireContext());
-        if (apiService == null) {
-            isLoadingMore = false;
-            playlistAdapter.setShowFooter(false);
+    private void changePage(int offset) {
+        if (isLoading) return;
+        if (offset < 0) {
+            if (currentPage <= 1) return;
             currentPage--;
+            showCurrentPage();
             return;
         }
 
-        apiService.getMiMusicPlaylists(100, (currentPage - 1) * 100).enqueue(new Callback<MiPlaylistListResponse>() {
-            @Override
-            public void onResponse(Call<MiPlaylistListResponse> call, Response<MiPlaylistListResponse> response) {
-                isLoadingMore = false;
-                playlistAdapter.setShowFooter(false);
-                if (response.isSuccessful() && response.body() != null && response.body().getPlaylists() != null) {
-                    List<MiPlaylist> miPlaylists = response.body().getPlaylists();
-                    hasMore = miPlaylists.size() >= 100;
-                    List<Playlist> convertedPlaylists = new ArrayList<>();
-                    for (MiPlaylist miPlaylist : miPlaylists) {
-                        convertedPlaylists.add(miPlaylist.toPlaylist());
-                    }
-                    playlists.addAll(convertedPlaylists);
-                    playlistAdapter.addData(convertedPlaylists);
-                } else {
-                    currentPage--;
-                }
-            }
+        int nextStart = currentPage * TV_PAGE_SIZE;
+        int cachedRemaining = loadedPlaylists.size() - nextStart;
+        if (cachedRemaining >= TV_PAGE_SIZE || (!remoteHasMore && cachedRemaining > 0)) {
+            currentPage++;
+            showCurrentPage();
+        } else if (remoteHasMore) {
+            remotePage++;
+            loadPlaylists(true);
+        }
+    }
 
-            @Override
-            public void onFailure(Call<MiPlaylistListResponse> call, Throwable t) {
-                isLoadingMore = false;
-                playlistAdapter.setShowFooter(false);
-                currentPage--;
-            }
-        });
+    private void showCurrentPage() {
+        int start = (currentPage - 1) * TV_PAGE_SIZE;
+        int end = Math.min(start + TV_PAGE_SIZE, loadedPlaylists.size());
+        playlists.clear();
+        if (start < end) {
+            playlists.addAll(loadedPlaylists.subList(start, end));
+        }
+        updatePlaylistList();
+        if (rvPlaylists != null) {
+            rvPlaylists.scrollToPosition(0);
+        }
+        updatePager();
+    }
+
+    private void updatePager() {
+        if (tvPageNumber != null) {
+            tvPageNumber.setText("第 " + currentPage + " 页");
+        }
+        if (btnPrevPage != null) {
+            btnPrevPage.setEnabled(!isLoading && currentPage > 1);
+            btnPrevPage.setAlpha(btnPrevPage.isEnabled() ? 1.0f : 0.35f);
+        }
+        if (btnNextPage != null) {
+            boolean hasCachedNextPage = currentPage * TV_PAGE_SIZE < loadedPlaylists.size();
+            btnNextPage.setEnabled(!isLoading && (hasCachedNextPage || remoteHasMore));
+            btnNextPage.setAlpha(btnNextPage.isEnabled() ? 1.0f : 0.35f);
+        }
     }
 
     private void updatePlaylistList() {
@@ -350,8 +321,20 @@ public class SongSquareFragment extends Fragment {
     
     private static class SongListResult {
         private List<Playlist> list;
+        private int limit;
+        private int total;
         
         public List<Playlist> getList() { return list; }
+
+        boolean hasMore(int page, int receivedCount) {
+            if (limit > 0 && total > 0) {
+                return page * limit < total;
+            }
+            if (limit > 0) {
+                return receivedCount >= limit;
+            }
+            return receivedCount >= 20;
+        }
     }
     
     private static class SourceViewHolder extends RecyclerView.ViewHolder {
@@ -365,6 +348,27 @@ public class SongSquareFragment extends Fragment {
     }
     
     public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+            View focusedView = rvPlaylists != null ? rvPlaylists.findFocus() : null;
+            if (focusedView != null && gridLayoutManager != null && playlistAdapter != null) {
+                int position = gridLayoutManager.getPosition(focusedView);
+                int itemCount = playlists.size();
+                int lastRowStart = itemCount == 0 ? 0 : ((itemCount - 1) / spanCount) * spanCount;
+                if (position != RecyclerView.NO_POSITION && position >= lastRowStart) {
+                    if (btnNextPage != null && btnNextPage.isEnabled()) {
+                        return btnNextPage.requestFocus();
+                    }
+                    if (btnPrevPage != null && btnPrevPage.isEnabled()) {
+                        return btnPrevPage.requestFocus();
+                    }
+                    View tabSongSquare = getActivity() != null
+                            ? getActivity().findViewById(R.id.tabSongSquare)
+                            : null;
+                    return tabSongSquare != null && tabSongSquare.requestFocus();
+                }
+            }
+        }
+
         if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
             if (rvPlaylists != null && gridLayoutManager != null) {
                 View focusedView = rvPlaylists.findFocus();
@@ -411,5 +415,24 @@ public class SongSquareFragment extends Fragment {
         }
         
         return false;
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (activePageCall != null) {
+            activePageCall.cancel();
+            activePageCall = null;
+        }
+        if (floatingPlayerWindow != null) {
+            floatingPlayerWindow.release();
+            floatingPlayerWindow = null;
+        }
+        rvSourceList = null;
+        rvPlaylists = null;
+        loadingProgress = null;
+        btnPrevPage = null;
+        btnNextPage = null;
+        tvPageNumber = null;
+        super.onDestroyView();
     }
 }

--- a/app/src/main/res/layout/fragment_song_square.xml
+++ b/app/src/main/res/layout/fragment_song_square.xml
@@ -27,11 +27,58 @@
         android:layout_height="0dp"
         android:padding="16dp"
         android:descendantFocusability="afterDescendants"
-        android:nextFocusDown="@id/bottomNav"
+        android:nextFocusDown="@id/btnNextPage"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/rvSourceList"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintBottom_toTopOf="@+id/pagerBar" />
+
+    <LinearLayout
+        android:id="@+id/pagerBar"
+        android:layout_width="0dp"
+        android:layout_height="56dp"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:background="#40000000"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <Button
+            android:id="@+id/btnPrevPage"
+            android:layout_width="140dp"
+            android:layout_height="44dp"
+            android:text="上一页"
+            android:textAllCaps="false"
+            android:textColor="#FFFFFF"
+            android:focusable="true"
+            android:nextFocusUp="@id/rvPlaylists"
+            android:nextFocusRight="@id/btnNextPage"
+            android:nextFocusDown="@id/tabSongSquare" />
+
+        <TextView
+            android:id="@+id/tvPageNumber"
+            android:layout_width="130dp"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="第 1 页"
+            android:textSize="18sp"
+            android:textColor="#FFFFFF" />
+
+        <Button
+            android:id="@+id/btnNextPage"
+            android:layout_width="140dp"
+            android:layout_height="44dp"
+            android:text="下一页"
+            android:textAllCaps="false"
+            android:textColor="#FFFFFF"
+            android:focusable="true"
+            android:nextFocusUp="@id/rvPlaylists"
+            android:nextFocusLeft="@id/btnPrevPage"
+            android:nextFocusDown="@id/tabSongSquare" />
+    </LinearLayout>
 
     <!-- Loading -->
     <ProgressBar


### PR DESCRIPTION
> [!IMPORTANT]
> **AI 声明：本 PR 的代码修改由 OpenAI Codex 100% 生成并实现；用户负责提出问题并完成实机行为验证。**

## 修复内容

- 将 LXserver 认证改为 `/api/user/login`，保存令牌，并在播放令牌缺失或返回 401 时自动重新登录。
- 音乐 URL 请求携带用户名、密码和令牌；保留后端返回的外部直链，只为相对地址补全服务器地址。
- 使用 Media3 默认缓冲策略，避免固定 30 秒最大缓冲造成长时间播放中断。
- 增强 MediaController、悬浮播放器和 Fragment 的生命周期清理，降低退出再进入时的闪退概率。
- 歌单广场移除无限滚动，改为每页 12 项（6×2）以及“上一页 / 下一页”，最后一行按遥控器下键可进入翻页栏，再向下可回到底部导航。
- 播放失败时显示完整错误链并支持复制，便于后续诊断。
- 保留上游 main 的 MiMusic 和主题相关实现，没有回退正式版 UI。

## 验证

- `./gradlew assembleDebug` 完整构建成功。
- 最终小调整后再次增量构建成功。
- 同源修复已在 v1.1.7 实机包中由用户验证：可播放、分页可操作；本 PR 是面向当前 `main` 的兼容移植。

## 提交

- `1a5bf64` — `fix: stabilize LXserver playback and TV navigation`
